### PR TITLE
Add OVMF build instruction

### DIFF
--- a/2_BASIC_SETUP.md
+++ b/2_BASIC_SETUP.md
@@ -12,12 +12,12 @@ For a full installation, the following software is required:
 - the Virtio drivers, which accelerate various emulated hardware;
 - and of course, QEMU.
 
-Download and installl the OVMF Ubuntu package:
+QEMU 2.9 (or earlier) users can download and install the latest OVMF Ubuntu package:
 
-    wget http://de.archive.ubuntu.com/ubuntu/pool/universe/e/edk2/ovmf_0~20160813.de74668f-1_all.deb
-    dpkg -i ovmf_0~20160813.de74668f-1_all.deb
+    wget http://de.archive.ubuntu.com/ubuntu/pool/universe/e/edk2/ovmf_0~20161202.7bbe0b3e-1_all.deb -O /tmp/ovmf.deb
+    dpkg -i /tmp/ovmf.deb
 
-note that the Xenial version is buggy and must not be used; the Yakkety version (above) never caused issues on my system.
+QEMU 2.10 users must [build the package from the OVMF repository](#build-the-ovmf-firmware-qemu-210), since this release uncovers some significant bugs in the OVMF version packaged by Ubuntu.
 
 Download the Windows Virtio Drivers ISO image:
 
@@ -28,6 +28,43 @@ the Virtio website is https://fedoraproject.org/wiki/Windows_Virtio_Drivers.
 Install the QEMU package, plus utilities:
 
     apt-get install qemu-system-x86 qemu-utils
+
+### Build the OVMF firmware (QEMU 2.10+)
+
+Prepare the machine:
+
+    sudo apt-get install build-essential uuid-dev iasl git gcc-5 nasm
+
+Clone the repository and change path:
+
+    git clone https://github.com/tianocore/edk2.git
+    cd edk2
+
+Compile and build the tools:
+
+    make -C BaseTools
+    export EDK_TOOLS_PATH=$(pwd)/BaseTools
+    . edksetup.sh BaseTools
+
+Configure the build, in this case for an X64 target:
+
+    export COMPILATION_MAX_THREADS=$((1 + $(lscpu --all -p=CPU | grep -v ^# | sort | uniq | wc -l)))
+    
+    perl -i -pe 's/^(ACTIVE_PLATFORM).*              /$1 = OvmfPkg\/OvmfPkgX64.dsc/x'  Conf/target.txt
+    perl -i -pe 's/^(TOOL_CHAIN_TAG).*               /$1 = GCC5/x'                     Conf/target.txt
+    perl -i -pe 's/^(TARGET_ARCH).*                  /$1 = X64/x'                      Conf/target.txt
+    perl -i -pe "s/^(MAX_CONCURRENT_THREAD_NUMBER).*/\$1 = $COMPILATION_MAX_THREADS/x" Conf/target.txt
+
+Build:
+
+    build
+
+Enjoy!:
+
+    $ ls -1 Build/OvmfX64/DEBUG_GCC5/FV/OVMF_*.fd
+    Build/OvmfX64/DEBUG_GCC5/FV/OVMF_CODE.fd
+    Build/OvmfX64/DEBUG_GCC5/FV/OVMF_VARS.fd
+
 
 ## Intel only: enable IOMMU
 


### PR DESCRIPTION
Add the OVMF build instructions, in order to make the setup work on QEMU 2.10.

Addresses issue #10 .