### PR TITLE
Updates, assuming a modern system and O/S

### DIFF
--- a/1_INTRODUCTION_TO_VGA_PASSTHROUGH.md
+++ b/1_INTRODUCTION_TO_VGA_PASSTHROUGH.md
@@ -13,9 +13,9 @@ Of course, VGA Passthrough is not appropriate for those seeking 100% of performa
 
 ## Guide and audience orientation
 
-This guide is intended to be a walkthrough more than a troubleshooting guide.
+This guide is intended to be a walkthrough, more than a troubleshooting guide.
 
-The audience is therefore, people who have hardware already known to work well with VFIO, and want an easy, hassle-free, way to setup the virtualization, rather than those who spend hours trying to make passthrough work on unsupporting hardware, or to achieve impractical but ideal setups.
+Therefore, the audience is people who own hardware already known to work well with VFIO, and want an easy, hassle-free, way to setup the virtualization, rather than those who spend hours trying to make passthrough work on unsupported hardware, or to achieve impractical but ideal setups.
 
 This is not as obvious as it sounds, because there is a surprising amount of users willing to spend many hours trying to solve the infamous audio crackling issue, when a 3$ USB sound card solves the issue permanently and perfectly.
 
@@ -25,10 +25,10 @@ I think one common misunderstanding of VGA Passthrough is to conceptually put so
 
 This is not the case in real world: VGA Passthrough is not a very mature/supported technology yet, both in the software and hardware, and fixing certain issues is impossible without low-level knowledge of the technologies involved.
 
-Trying to hammer unsupporting hardware into working generally leads down the rabbit hole (where there is *always* one more change worth trying... that doesn't ultimately work), wasting large amounts of time and hair.
+Trying to hammer unsupported hardware to make it work generally leads down the rabbit hole (where there is *always* one more change worth trying... that doesn't ultimately work), wasting large amounts of time and hair.
 
-However mature though, the upside is that on systems where the VGA Passthrough works without tweaks, it's very solid, virtually with no issues.
+Independently of the maturity though, the upside is that on systems where the VGA Passthrough works without tweaks, it's very solid, virtually with no issues.
 
-For time-sensitive people, the best strategy is to briefly test if the system is compatible (by following this guide), and if it doesn't, to directly plan a system upgrade, without attempting any tweak.
+For time-sensitive people, my advice is to briefly test if the system is compatible (by following this guide), and if it doesn't, to plan a system upgrade, without attempting any tweak.
 
 [Previous: General introduction](README.md) | [Next: A word of caution](2_A_WORD_OF_CAUTION.md)

--- a/3_BASIC_SETUP.md
+++ b/3_BASIC_SETUP.md
@@ -4,6 +4,8 @@
 
 All the commands must be run with sudo permissions.
 
+This guide assumes a reasonably modern machine and O/S, since several things have changed in the last years (CPU power saving, bug fixes in the kernel, etc.).
+
 ## Install/prepare required software
 
 For a full installation, the following software is required:
@@ -41,14 +43,6 @@ Only on Intel systems, set the IOMMU kernel parameter:
 ```sh
 perl -i -pe 's/(GRUB_CMDLINE_LINUX_DEFAULT=.*)"/\1 intel_iommu=on"/' /etc/default/grub
 update-grub
-```
-
-## AMD only: disable nested paging
-
-It's been reported (also verified on my previous AMD system) that nested paging must be disabled on AMD 4ᵗʰ generation CPUS (Bulldozer, ...), otherwise the system will go very slow (loss of around 70% of performance):
-
-```sh
-echo "options kvm-amd npt=0" > /etc/modprobe.d/kvm-amd.conf
 ```
 
 ## Check IOMMU, and set the data
@@ -118,6 +112,20 @@ qemu-img create -f qcow2 /path/to/virtual_disk.img 128G
 ```
 
 In the example above, the size is 128 GiB (dynamically allocated, so it will start with a minimal occupation).
+
+## Set the `Performance` governor
+
+On at least some systems (eg. the Intel i7-6700k), the CPU frequency may not ramp up when required, causing low performance problems (ie. stuttering). This happens because [KVM cannot actually change the CPU frequency on its own](https://wiki.archlinux.org/index.php/PCI_passthrough_via_OVMF#CPU_frequency_governor).
+
+In the past, typically, tweaking the `ondemand` governor solved the problem, however, nowadays, the scaling system is different, and this governor is not available anymore.
+
+The easiest solution is to force the CPU to use the maximum frequency for all the cores, by using the `performance` governor; this can be enabled and disabled at wish, in this case, before and after the virtualization session.
+
+A governor widget is typically displayed in the system tray, and it allows setting the governors (`Powersave` and `Performance`. Alternatively, it can be enabled with a simple command:
+
+```sh
+echo performance | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
+```
 
 ## Execute QEMU, and install/prepare Windows
 

--- a/5_TROUBLESHOOTING.md
+++ b/5_TROUBLESHOOTING.md
@@ -48,4 +48,4 @@ In order to workaround this problem, add `kernel-irqchip=on` to the `-machine` o
 -machine q35,accel=kvm,mem-merge=off,kernel-irqchip=on
 ```
 
-QEMU 3.x users don't need this option.
+QEMU 3.x/4.1+ users don't need this option.

--- a/6_POSSIBLE_IMPROVEMENTS.md
+++ b/6_POSSIBLE_IMPROVEMENTS.md
@@ -1,30 +1,19 @@
 # Possible improvements
 
-## General improvements
+This section includes a list of possible improvements both to the configuration and the VM performance.
+
+With the proper configuration, covered fully until this point, my system yield already the "95% of native" performance, without stuttering; however, below I point some tweaks that may improve the performance of other users' setups.
+
+I find the best reference to be the [Arch passthrough wiki page](https://wiki.archlinux.org/index.php/PCI_passthrough_via_OVMF), so users may want to check it out.
+
+Thanks to Reddit user [tholin](https://www.reddit.com/user/tholin) for contributing specific details and improvements to this section.
+
+## Configuration improvements
 
 In this guide is not known:
 
 - whether there is a way to ensure that `vfio-pci` takes over before other drivers - maybe this is not required on any configuration;
 - whether `mem-merge=off` has overhead when only one VM is running at a time, or it doesn't (therefore, it's not meaningful to disable it);
-- the functionality of `kernel_irqchip=on`.
-
-## General optimizations
-
-The optimizations tried didn't yield any significant improvement, with a single exception for AMD platforms.
-
-Note that I try only their basic form, which in some cases may be insufficient; therefore, they may be effective when configured properly.
-
-Thanks to Reddit user [tholin](https://www.reddit.com/user/tholin) for contributing specific details and improvements to this section.
-
-### `performance` CPU governor
-
-Simply enabling it yielded a negligible improvement.
-
-It is reported that even when correctly setup, it makes a difference only on very specific cases (ie. workloads that change load a lot).
-
-Users that intend to try such tweak will also have to disable c-states.
-
-Reference: https://access.redhat.com/articles/65410
 
 ### CPU pinning
 
@@ -32,7 +21,7 @@ Simply enabling it (using [my patched QEMU fork](https://github.com/saveriomirod
 
 It is reported that it can reduce latency and stuttering in certain edge cases.
 
-Users that intend to try such tweak will also have to reserve the CPU cores to the VM for exclusive use.
+Users that intend to try such tweak should (but not necessarily) reserve the CPU cores to the VM for exclusive use.
 
 Reference: https://www.redhat.com/archives/vfio-users/2017-February/msg00010.html
 


### PR DESCRIPTION
Some concepts can be considered obsolete:

- the performance governor is now needed on some systems
- the nested paging AMD issue has been fixed in the kernel
- kernel-irqchip is not needed on the most recent QEMU

Also made minor stylistic improvements.