### PR TITLE
3_BASIC_SETUP: Add softdep approach to devices take over

### DIFF
--- a/3_BASIC_SETUP.md
+++ b/3_BASIC_SETUP.md
@@ -116,11 +116,28 @@ While it's possible that on some systems the device can be bound at any moment, 
 
 ## Ensure that the VGA drivers are not taking control of the card
 
-It's important to uninstall the host VGA drivers, if they are installed, as they may take over the card control before the VFIO driver.
+It's crucial to ensure that the vfio driver takes the card (components) over before the standard graphic driver does it.
 
-In case the drivers are standard part of the system (eg. nouveau), it's possible to blacklist them.
+There are two approaches to solve this problem.
 
-As of today, this document doesn't cover how to be 100% sure that VFIO takes control of one VGA, on a system with two cards from the same producer.
+The simplest is to uninstall the driver \[package\] or blacklist the driver; for example, in case of an Nvidia card:
+
+```sh
+# Execute one of the two.
+#
+$ apt purge "xserver-xorg-video-nouveau*"
+$ echo "blacklist nouveau" > /etc/modprobe.d/blacklist_nouveau.conf
+```
+
+The other approach is to use the [`softdep` modprobe command](https://www.systutorials.com/docs/linux/man/5-modprobe.d/), setting the load order via dependencies.
+
+```sh
+# Append this to the previously created file.
+#
+echo "softdep nouveau pre: vfio_pci" >> /etc/modprobe.d/vfio.conf
+```
+
+Note that this approach requires the name of the module as listed by `lsmod`, i.e. `vfio_pci` instead of `vfio-pci`. Feedback from other users on this subject would be helpful.
 
 ## Create a virtual disk
 

--- a/3_BASIC_SETUP.md
+++ b/3_BASIC_SETUP.md
@@ -98,8 +98,14 @@ VGAPT_VGA_AUDIO_BUS=01:00.1
 Bind the vfio driver to the graphic card before any other driver:
 
 ```sh
-echo options vfio-pci ids=$VGAPT_VGA_ID,$VGAPT_VGA_AUDIO_ID > /etc/modprobe.d/vfio.conf
-printf "vfio\nvfio_pci\n" > /etc/modules-load.d/vfio.conf
+cat > /etc/modprobe.d/vfio.conf << CONF
+options vfio-pci ids=$VGAPT_VGA_ID,$VGAPT_VGA_AUDIO_ID
+CONF
+
+cat > /etc/modules-load.d/vfio.conf << CONF
+vfio
+vfio_pci
+CONF
 
 update-initramfs -u
 ```


### PR DESCRIPTION
This is the cleanest approach, although feedback would be helpful, in particular to understand why the net refers only usage of the supposedly wrong `vfio-pci`.